### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,6 +3,9 @@ name: Build & Publish Package
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Miiraak/BlobPE/security/code-scanning/3](https://github.com/Miiraak/BlobPE/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
1. Most steps only require `contents: read` to access the repository's files.
2. The steps that publish packages to GitHub Packages and NuGet.org do not require `contents: write` because they use explicit secrets for authentication.
3. No other permissions (e.g., `actions`, `issues`, `pull-requests`) are needed.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, ensuring consistency and reducing the risk of overly permissive access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
