### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-package-github.yml
+++ b/.github/workflows/publish-package-github.yml
@@ -3,6 +3,10 @@ name: Build & Publish BlobPE to GitHub Packages (Manual Only/Main)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Miiraak/BlobPE/security/code-scanning/4](https://github.com/Miiraak/BlobPE/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow:
1. The `contents: read` permission is required to check out the repository.
2. The `packages: write` permission is required to publish the NuGet package to GitHub Packages.
3. The `contents: read` permission is also sufficient for verifying the publication of the package.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as all steps in the workflow require these permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
